### PR TITLE
Fix cmdlinergen: reset counter for positional arguments

### DIFF
--- a/lib/cmdlinergen.ml
+++ b/lib/cmdlinergen.ml
@@ -126,6 +126,7 @@ module Gen () = struct
           Cmdliner.Term.(const (fun args -> run args) $ cur)
       in
       let doc = String.concat " " desc_list in
+      pos := 0;
       inner (Cmdliner.Term.pure []) ty, Cmdliner.Term.info name ~doc
     in
     terms := generate :: !terms


### PR DESCRIPTION
While generating terms for each argument in an RPC call, we have to
start from position 0 for the first call. Previously we did not reset
this counter when moving to the translation of the next call.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>