### PR TITLE
Fix `opam` file and the Travis CI build

### DIFF
--- a/opam
+++ b/opam
@@ -27,6 +27,7 @@ depends: [
   "cow"
   "xmlm"
   "lwt"
+  "cmdliner"
   "rresult"
   "async"
 ]

--- a/opam
+++ b/opam
@@ -20,5 +20,7 @@ depends: [
   "cow"
   "xmlm"
   "lwt"
+  "rresult"
+  "async"
 ]
 depopts: [ "js_of_ocaml" ]

--- a/opam
+++ b/opam
@@ -1,11 +1,18 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+homepage: "https://github.com/mirage/ocaml-rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+dev-repo: "git://github.com/mirage/ocaml-rpc"
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
+  [configure]
   [make]
+]
+install: [
   [make "install"]
 ]
 remove: [


### PR DESCRIPTION
Update the `opam` file and add some missing dependencies. The changes in this PR also fix the [Travis CI build](https://travis-ci.org/gaborigloi/ocaml-rpc).

I'm not sure why there is a `configure` step in the `opam` file: there doesn't seem to be any configure script in the repo, and the Makefile already does the configuration step automatically. And I'm not sure why the Travis build was passing with this `[configure]` step in the opam file. I also have a branch without the `configure` step, and its [Travis build](https://travis-ci.org/gaborigloi/ocaml-rpc) is also passing: <https://github.com/gaborigloi/ocaml-rpc/tree/ppx2_remove_configure_step>